### PR TITLE
Use the correct file name when we can't find by suffix

### DIFF
--- a/src/EPF/Autoload.php
+++ b/src/EPF/Autoload.php
@@ -231,6 +231,7 @@ class Autoload
 		}
 		
 		// Not found, try the class name
+		$class = substr($class, strrpos($class, '\\') + 1);
 		$path = $prefix ."/". $class .".php";
 		if(is_file($path))
 		{


### PR DESCRIPTION
Maintainers
===========

@ErrLock-Admin New PR

Description
===========

We were using a filename made of the classname including the namespace.