### PR TITLE
Put only data in the DOM.

### DIFF
--- a/src/EPF/API/Entity.php
+++ b/src/EPF/API/Entity.php
@@ -179,15 +179,15 @@ class Entity extends EntityBase
 		// Clone it, only us should modify it
 		$dom = clone $this->dom;
 		
-		$dom->setProperty("@self", $this);
-		$dom->setProperty("@index", $this->getIndex());
+		//~ $dom->setProperty("@self", $this);
+		//~ $dom->setProperty("@index", $this->getIndex());
 		
-		$col = $this->getCollection();
-		if(isset($col))
-		{
-			$dom->setProperty("@collection", $col);
-			$dom->setProperty("@up", $col);
-		}
+		//~ $col = $this->getCollection();
+		//~ if(isset($col))
+		//~ {
+			//~ $dom->setProperty("@collection", $col);
+			//~ $dom->setProperty("@up", $col);
+		//~ }
 		
 		return  $dom;
 	}

--- a/src/EPF/API/EntityBase.php
+++ b/src/EPF/API/EntityBase.php
@@ -34,6 +34,7 @@ namespace EPF\API;
 abstract class EntityBase
 {
 	private $name = null;
+	private $collection = null;
 	
 	abstract public function getDOM();
 	abstract public function getProperties();
@@ -80,7 +81,7 @@ abstract class EntityBase
 	 */
 	public function getCollection()
 	{
-		return $this->getProperty("@collection");
+		return $this->collection;
 	}
 	
 	/**
@@ -96,17 +97,17 @@ abstract class EntityBase
 	{
 		// @index is the topmost collection
 		$index = $this;
-		$col = null;
-		do
+		while(($col = $index->getCollection()) != null)
 		{
-			$col = $index->getCollection();
-			if(!isset($col))
-			{
-				return $index;
-			}
 			$index = $col;
 		}
-		while(isset($col));
+		
+		if(!is_a($index, Server::class))
+		{
+			throw new \Error("Index is not a ". Server::class);
+		}
+		
+		return $index;
 	}
 	
 	/**
@@ -134,7 +135,7 @@ abstract class EntityBase
 	 */
 	public function getURI()
 	{
-		$parent = $this->getProperty("@collection");
+		$parent = $this->getCollection();
 		$name = $this->getName();
 		
 		if(is_null($parent))
@@ -168,11 +169,7 @@ abstract class EntityBase
 		switch($type)
 		{
 			case "object":
-				$type = get_class($value);
-				if(
-					is_a($value, Entity::class) ||
-					is_a($value, EntityRef::class)
-				)
+				if(is_a($value, self::class))
 				{
 					$valid = true;
 					$type = "link";
@@ -204,9 +201,14 @@ abstract class EntityBase
 	 * 
 	 * @retval type Desc
 	 */
-	protected function populate()
+	protected function setCollection(EntityBase $value)
 	{
-	
+		if(isset($this->collection))
+		{
+			throw new \Error("Collection already set");
+		}
+		
+		$this->collection = $value;
 	}
 }
 ?>

--- a/src/EPF/API/EntityRef.php
+++ b/src/EPF/API/EntityRef.php
@@ -76,7 +76,7 @@ class EntityRef extends EntityBase
 	public function getDOM()
 	{
 		$result = $this->target->getDOM();
-		$result->setProperty("@up", parent::getCollection());
+		//~ $result->setProperty("@up", parent::getCollection());
 		return $result;
 	}
 	

--- a/src/EPF/API/EntityRef.php
+++ b/src/EPF/API/EntityRef.php
@@ -27,18 +27,13 @@
 
 namespace EPF\API;
 
-use EPF\StdClass\Friend;
-
 /**
  * @brief 
  * @details 
  */
 class EntityRef extends EntityBase
 {
-	use Friend;
-	
 	private $target = null;
-	private $up = null;
 	
 	/**
 	 * @brief 
@@ -51,7 +46,6 @@ class EntityRef extends EntityBase
 	 */
 	public function __construct(EntityBase $target)
 	{
-		self::_friend_init();
 		$this->target = $target;
 		parent::__construct($target->getName());
 	}
@@ -65,9 +59,9 @@ class EntityRef extends EntityBase
 	 * 
 	 * @retval type Desc
 	 */
-	private static function _friend_config()
+	public function getCollection()
 	{
-		self::_friend(Entity::class);
+		return $this->target->getCollection();
 	}
 	
 	/**
@@ -82,7 +76,7 @@ class EntityRef extends EntityBase
 	public function getDOM()
 	{
 		$result = $this->target->getDOM();
-		$result->setProperty("@up", $this->getProperty("@up"));
+		$result->setProperty("@up", parent::getCollection());
 		return $result;
 	}
 	
@@ -97,9 +91,7 @@ class EntityRef extends EntityBase
 	 */
 	public function getProperties()
 	{
-		$result = $this->target->getProperties();
-		$result["@up"] = $this->up;
-		return $result;
+		return $this->target->getProperties();
 	}
 	
 	/**
@@ -113,11 +105,6 @@ class EntityRef extends EntityBase
 	 */
 	public function getProperty(string $name)
 	{
-		if($name == "@up")
-		{
-			return $this->up;
-		}
-		
 		return $this->target->getProperty($name);
 	}
 	
@@ -132,11 +119,6 @@ class EntityRef extends EntityBase
 	 */
 	public function hasProperty(string $name)
 	{
-		if($name == "@up" && isset($this->up))
-		{
-			return $this->up;
-		}
-		
 		return $this->target->hasProperty($name);
 	}
 	
@@ -151,38 +133,7 @@ class EntityRef extends EntityBase
 	 */
 	protected function setProperty(string $name, $value)
 	{
-		throw new \Error("Entity references doesn't have properties");
-	}
-	
-	/**
-	 * @brief 
-	 * 
-	 * @param[in] type name Desc
-	 * 
-	 * @exception type Desc
-	 * 
-	 * @retval type Desc
-	 */
-	final protected function set_property(string $name, $value)
-	{
-		if($name != "@collection")
-		{
-			throw new \error("Trying to set ". $name ." on ". get_class($this));
-		}
-		if(isset($this->up))
-		{
-			throw new \Error("@up already set");
-		}
-		if(!is_a($value, parent::class))
-		{
-			throw new \Error("Invalid type");
-		}
-		if($value->getIndex() !== $this->target->getIndex())
-		{
-			throw new \Error("Different API");
-		}
-		
-		$this->up = $value;
+		throw new \Error("Entity references don't have properties");
 	}
 }
 ?>

--- a/tests/API/resources/ServerFromClass.php
+++ b/tests/API/resources/ServerFromClass.php
@@ -7,12 +7,15 @@ use EPF\API\Server;
 
 class FriendsList extends Entity
 {
+	private $player = null;
 	private $all_children = array(
-		"player2"
+		"player1" => array( "player2" ),
+		"player2" => array()
 	);
 	
-	public function __construct(string $name = "friends")
+	public function __construct(string $player, string $name = "friends")
 	{
+		$this->player = $player;
 		parent::__construct($name);
 	}
 	
@@ -32,7 +35,7 @@ class FriendsList extends Entity
 		 * We fully populate the dom only if asked for it
 		 */
 		parent::populate();
-		foreach($this->all_children as $name)
+		foreach($this->all_children[$this->player] as $name)
 		{
 			$this->check_player($name);
 		}
@@ -42,11 +45,11 @@ class FriendsList extends Entity
 	{
 		if(
 			!$this->hasProperty($name)
-			&& in_array($name, $this->all_children)
+			&& in_array($name, $this->all_children[$this->player])
 		)
 		{
-			$player = $this->getIndex()->GET("/players/". $name);
-			$this->setProperty($name, new EntityRef($player));
+			$target = $this->getIndex()->GET("/players/". $name);
+			$this->setProperty($name, new EntityRef($target));
 		}
 	}
 }
@@ -57,18 +60,20 @@ class EntityPlayer extends Entity
 	{
 		parent::__construct($name);
 		
-		$displayName = null;
 		switch($this->getName())
 		{
 			case "player1":
-				$displayName = "Player 1";
+				$this->setProperty("firstName", "Kevin");
+				$this->setProperty("lastName", "Sookocheff");
+				$this->setProperty("pseudonym", "soofaloofa");
 				break;
 			case "player2":
-				$displayName = "Player 2";
+				$this->setProperty("firstName", "Albert");
+				$this->setProperty("lastName", "Hofmann");
+				$this->setProperty("pseudonym", "bicycleman");
 				break;
 		}
-		$this->setProperty("displayName", $displayName);
-		$this->setProperty("friends", new FriendsList());
+		$this->setProperty("friends", new FriendsList($name));
 	}
 }
 

--- a/tests/API/resources/ServerFromClass.php
+++ b/tests/API/resources/ServerFromClass.php
@@ -60,17 +60,20 @@ class EntityPlayer extends Entity
 	{
 		parent::__construct($name);
 		
+		$a_url = $this->getURI() ."/avatar.png";
 		switch($this->getName())
 		{
 			case "player1":
 				$this->setProperty("firstName", "Kevin");
 				$this->setProperty("lastName", "Sookocheff");
 				$this->setProperty("pseudonym", "soofaloofa");
+				$this->setProperty("avatar", new Entity($a_url));
 				break;
 			case "player2":
 				$this->setProperty("firstName", "Albert");
 				$this->setProperty("lastName", "Hofmann");
 				$this->setProperty("pseudonym", "bicycleman");
+				$this->setProperty("avatar", new Entity($a_url));
 				break;
 		}
 		$this->setProperty("friends", new FriendsList($name));


### PR DESCRIPTION
Maintainers
===========

@ErrLock-Admin New PR

Description
===========

The DOM used by the API should contains only information about the data itself.
Data doesn't know about relations (collection, index...), the API does.

The client wants to know about relations, XSLT will take care of that.

Motivations
===========

Try to keep our data/representation separation.

Drawbacks
=========

We come back to our original problem about how to give 'complex' data to an
XSLT processor.